### PR TITLE
Multiple message lines

### DIFF
--- a/src/routes/channel/[id]/channelMessage.ts
+++ b/src/routes/channel/[id]/channelMessage.ts
@@ -144,6 +144,7 @@ export const linkify = (text: string) => {
   const channelPattern = /#<(\d+)>/g;
   const codeSnippetPattern = /```([^`]+)```/g;
   const inlineCodePattern = /`([^`]+)`/g;
+  const breakLinePattern = /\n/g;
 
   // スクリプトタグをエスケープ
   text = text.replace(scriptPattern, (match) => {
@@ -206,6 +207,16 @@ export const linkify = (text: string) => {
     placeholders.push({
       placeholder,
       content: `<code class=" bg-gray-100 p-1 rounded">${code}</code>`,
+    });
+    return placeholder;
+  });
+
+  // 改行を変換
+  text = text.replace(breakLinePattern, (match) => {
+    const placeholder = `__PLACEHOLDER_${placeholderIndex++}__`;
+    placeholders.push({
+      placeholder,
+      content: `<br>`,
     });
     return placeholder;
   });

--- a/src/routes/channel/[id]/messageInput.svelte
+++ b/src/routes/channel/[id]/messageInput.svelte
@@ -2,13 +2,26 @@
   import { createEventDispatcher } from "svelte";
 
   export let message = "";
+  let inputRows = 1; //入力部分の行数
+
+  $: {
+    //メッセージの改行に合わせて
+    if (message.split("\n").length > 5) {
+      inputRows = 5;
+    } else if (message.split("\n").length < 1) {
+      inputRows = 1;
+    } else {
+      inputRows = message.split("\n").length;
+    }
+  }
 
   const dispatch = createEventDispatcher();
 
   const handleKeyDown = (event: KeyboardEvent) => {
     if (
-      navigator.platform.toUpperCase().indexOf("MAC") >= 0 &&
-      event.keyCode === 229
+      (navigator.platform.toUpperCase().indexOf("MAC") >= 0 &&
+        event.keyCode === 229) ||
+      event.shiftKey
     ) {
       return;
     }
@@ -26,11 +39,12 @@
   };
 </script>
 
-<input
+<textarea
   bind:value={message}
-  type="text"
   placeholder="メッセージを送信"
-  class="input input-bordered w-full flex-grow"
+  class="textarea textarea-bordered w-full flex-grow"
+  rows={inputRows}
+  wrap="soft"
   on:keydown={handleKeyDown}
 />
 <button on:click={sendMessage} class="btn">送信</button>


### PR DESCRIPTION
メッセージの複数行入力に対応
Shift + Enterで改行

ただ、現状として１行で長文を入力されると折り返すようにはしたけどtextareaの行数表示が拡大されず窮屈になってしまう。（textareaの行数判別として入力された本文中の`\n`の数としている）